### PR TITLE
fix: pin mlkit versions to prevent crash in scanning on android

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   # https://pub.dev/packages/camera
   camera: ^0.11.0+2
   # https://pub.dev/packages/google_mlkit_text_recognition
-  google_mlkit_text_recognition: ^0.13.0
+  google_mlkit_text_recognition: 0.13.0
   # https://pub.dev/packages/google_mlkit_barcode_scanning
-  google_mlkit_barcode_scanning: ^0.12.0
+  google_mlkit_barcode_scanning: 0.12.0
   # https://pub.dev/packages/native_device_orientation
   native_device_orientation: ^2.0.3
 


### PR DESCRIPTION
### Proposed changes

Currently, the scanning of mlkit is broken on some Android devices (specifically SBB devices) with the latest versions of the mlkit.

This pins the last working versions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation