### PR TITLE
ci: fix flutter minor version in test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.27.x
           cache: true
 
       - name: flutter setup
@@ -59,12 +60,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ["3.19.6", ""]
+        sdk: ["3.19.6", "3.27.x"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
+          channel: stable
           flutter-version: ${{ matrix.sdk }}
           cache: true
 
@@ -87,12 +89,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ["3.19.6", ""]
+        sdk: ["3.19.6", "3.27.x"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
+          channel: stable
           flutter-version: ${{ matrix.sdk }}
           cache: true
 


### PR DESCRIPTION
### Proposed changes

In order not to mix changes of the Flutter SDK with test outcome, we also fix the upper Flutter SDK version to a minor version (note that patches will be taken from latest available on stable).

Only in the nightly build, the Flutter SDK is **not** limited (for early failure alerting).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation