### PR TITLE
fix: rotate camera preview on android only when rotateOnAndroid param…

### DIFF
--- a/lib/widgets/data_scanner.dart
+++ b/lib/widgets/data_scanner.dart
@@ -72,6 +72,9 @@ class DataScannerConfiguration<T> {
   /// Whether to show the torch toggle. Defaults to `false`.
   final bool showTorchToggle;
 
+  /// Whether to rotate the camera preview on Android. Defaults to `false`. Consider this a workaround!
+  final bool rotateOnAndroid;
+
   /// Where to position the torch toggle. Defaults to [Alignment.bottomCenter]
   final Alignment torchToggleAlignment;
 
@@ -100,6 +103,7 @@ class DataScannerConfiguration<T> {
     this.torchToggleAlignment = Alignment.bottomCenter,
     this.torchToggleMargin = const EdgeInsets.all(32),
     this.detectionOutline,
+    this.rotateOnAndroid = false,
     RouteObserver<ModalRoute>? routeObserver,
   }) : _routeObserver = routeObserver ?? RouteObserver();
 }
@@ -387,6 +391,7 @@ class _DataScannerState<T> extends State<DataScanner> with RouteAware {
             SizedCameraPreview(
               size: _calculatedSize!,
               cameraController: cameraController,
+              rotateOnAndroid: scannerConfiguration.rotateOnAndroid,
             ),
             if (scannerConfiguration.showOverlay)
               CameraOverlay(

--- a/lib/widgets/sized_camera_preview.dart
+++ b/lib/widgets/sized_camera_preview.dart
@@ -5,6 +5,9 @@ import 'package:flutter/material.dart';
 
 /// Sized and scaled [CameraPreview] wrapper.
 class SizedCameraPreview<T> extends StatefulWidget {
+  /// temporary Workaround: rotate Camera Preview on Android Devices
+  final bool rotateOnAndroid;
+
   /// Size of the clipped preview.
   final Size size;
 
@@ -15,6 +18,7 @@ class SizedCameraPreview<T> extends StatefulWidget {
     Key? key,
     required this.size,
     required this.cameraController,
+    this.rotateOnAndroid = false,
   }) : super(key: key);
 
   @override
@@ -48,7 +52,7 @@ class _SizedCameraPreviewState<T> extends State<SizedCameraPreview> {
   }
 
   Widget _rotatedOnAndroid(Widget content) {
-    if (Platform.isAndroid) {
+    if (widget.rotateOnAndroid && Platform.isAndroid) {
       return RotatedBox(
         quarterTurns: 1,
         child: content,


### PR DESCRIPTION
…eter is true

### Proposed changes

Hand over responsibility for the camera rotation to the apps

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ x] I have updated any relevant documentation